### PR TITLE
Extension logo is misspelled

### DIFF
--- a/component/com_contactus.xml
+++ b/component/com_contactus.xml
@@ -62,7 +62,7 @@
 	<administration>
 		<!-- Administration menu -->
 		<menu view="items"
-			img="../media/com_cotnactus/images/contactus-16.png">COM_CONTACTUS</menu>
+			img="../media/com_contactus/images/contactus-16.png">COM_CONTACTUS</menu>
 
 		<!-- Back-end files -->
 		<files folder="backend">


### PR DESCRIPTION
I have corrected a misspelled logo image name for Joomla 2.5.

Also mention that in media/images/contactus-16.png the image is missing. So it will need to be added to make it work
