### PR TITLE
Update minimum Joomla version and modernize API calls

### DIFF
--- a/build/templates/contactus.xml
+++ b/build/templates/contactus.xml
@@ -12,10 +12,10 @@
 	<author>Nicholas K. Dionysopoulos</author>
 	<authorEmail>nicholas@akeeba.com</authorEmail>
 	<authorUrl>https://www.akeeba.com</authorUrl>
-	<copyright>Copyright (c)2013-2025 Nicholas K. Dionysopoulos / Akeeba Ltd</copyright>
+	<copyright>Copyright (c)2013-2026 Nicholas K. Dionysopoulos / Akeeba Ltd</copyright>
 	<license>GNU GPL v3 or later</license>
 	<version>##VERSION##</version>
-	<description>A simple contact form component used to demonstrate the FOF 3 framework</description>
+	<description>A category-based contact form component for Joomla! 4.4 to 7.0</description>
 	<namespace path="src">Akeeba\Component\ContactUs</namespace>
 
 	<!-- Public front end files -->

--- a/component/backend/src/View/Category/HtmlView.php
+++ b/component/backend/src/View/Category/HtmlView.php
@@ -69,7 +69,7 @@ class HtmlView extends BaseHtmlView
 
 	protected function addToolbar(): void
 	{
-		Factory::getApplication()->input->set('hidemainmenu', true);
+		Factory::getApplication()->getInput()->set('hidemainmenu', true);
 
 		$isNew = empty($this->item->contactus_category_id);
 

--- a/component/backend/src/View/Item/HtmlView.php
+++ b/component/backend/src/View/Item/HtmlView.php
@@ -69,7 +69,7 @@ class HtmlView extends BaseHtmlView
 
 	protected function addToolbar(): void
 	{
-		Factory::getApplication()->input->set('hidemainmenu', true);
+		Factory::getApplication()->getInput()->set('hidemainmenu', true);
 
 		ToolbarHelper::title(Text::_('COM_CONTACTUS_TITLE_ITEMS_EDIT'), 'fa fa-envelope');
 

--- a/component/frontend/src/Model/ItemModel.php
+++ b/component/frontend/src/Model/ItemModel.php
@@ -87,7 +87,7 @@ class ItemModel extends AdminItemModel
 
 			if (!is_null($captcha))
 			{
-				$this->assert($captcha->checkAnswer(Factory::getApplication()->input->get('captcha', '', 'raw')), 'COM_CONTACTUS_ITEM_ERR_CAPTCHA');
+				$this->assert($captcha->checkAnswer(Factory::getApplication()->getInput()->get('captcha', '', 'raw')), 'COM_CONTACTUS_ITEM_ERR_CAPTCHA');
 			}
 		}
 		catch (Exception $e)

--- a/component/script.contactus.php
+++ b/component/script.contactus.php
@@ -14,7 +14,7 @@ class Pkg_ContactusInstallerScript extends InstallerScript
 {
 	protected $minimumPhp = '7.4.0';
 
-	protected $minimumJoomla = '4.3.0';
+	protected $minimumJoomla = '4.4.0';
 
 	protected $allowDowngrades = true;
 


### PR DESCRIPTION
## Summary

This PR updates the ContactUs component to support Joomla 4.4+ and modernizes deprecated API calls to use current Joomla conventions.

## Key Changes

- **Minimum Joomla version**: Updated from 4.3.0 to 4.4.0 in `component/script.contactus.php`
- **Copyright year**: Bumped to 2026 in the component manifest
- **Component description**: Updated to reflect the category-based contact form functionality and supported Joomla versions (4.4 to 7.0)
- **API modernization**: Replaced deprecated `Factory::getApplication()->input` property access with `Factory::getApplication()->getInput()` method calls in:
  - `component/backend/src/View/Category/HtmlView.php`
  - `component/backend/src/View/Item/HtmlView.php`
  - `component/frontend/src/Model/ItemModel.php`

## Implementation Details

The `getInput()` method is the recommended approach in modern Joomla versions for accessing the application input object, replacing direct property access which may be deprecated or removed in future versions. This change ensures compatibility with Joomla 4.4+ while maintaining the same functionality.

https://claude.ai/code/session_01ELfNLVEpNpmpwb1ZXuBobL